### PR TITLE
Rust-ify fmt::Display for Representation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -86,29 +86,15 @@ struct Representation {
 
 impl fmt::Display for Representation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Err(fmt::Error) = self.fg_color.write_fg(f) {
-            return Err(fmt::Error);
-        }
+        self.fg_color.write_fg(f)?;
+        self.bg_color.write_bg(f)?;
+        f.write_str(&self.text)?;
 
-        if let Err(fmt::Error) = self.bg_color.write_bg(f) {
-            return Err(fmt::Error);
-        }
+        let reset = color::Reset {};
+        reset.write_fg(f)?;
+        reset.write_bg(f)?;
 
-        if let Err(fmt::Error) = f.write_str(&self.text) {
-            return Err(fmt::Error);
-        }
-
-        let reset = color::Reset{};
-
-        if let Err(fmt::Error) = reset.write_fg(f) {
-            return Err(fmt::Error);
-        }
-
-        if let Err(fmt::Error) = reset.write_bg(f) {
-            return Err(fmt::Error);
-        }
-        
-        return Ok(());
+        Ok(())
     }
 }
 


### PR DESCRIPTION
One neat thing about Rust is that `?` convention does exactly what you were doing earlier with the `if let`s, at least in any function with a `Result` return signature. If there are any errors, return that. Otherwise proceed as normal.

And the final return value is now an implicit return.

I ran `cargo run` on my machine to verify that it works, but let me know if it works for you. Also no need to merge, more of a show-and-tell than anything!